### PR TITLE
Prevent InvalidOperationExceptions in multi-threaded environments

### DIFF
--- a/src/Clave.Expressionify/ExpressionifyVisitor.cs
+++ b/src/Clave.Expressionify/ExpressionifyVisitor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -8,7 +9,7 @@ namespace Clave.Expressionify
 {
     public class ExpressionifyVisitor : ExpressionVisitor
     {
-        private static readonly IDictionary<MethodInfo, object> MethodToExpressionMap = new Dictionary<MethodInfo, object>();
+        private static readonly IDictionary<MethodInfo, object> MethodToExpressionMap = new ConcurrentDictionary<MethodInfo, object>();
 
         private readonly Dictionary<ParameterExpression, Expression> _replacements = new Dictionary<ParameterExpression, Expression>();
 


### PR DESCRIPTION
First I want to say, thank you for providing this great NuGet package.

We use Expressionify in almost every EF Core query of our web application.
In rare occurrences we get Exceptions with a stack trace like this:
```
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at System.Collections.Generic.Dictionary`2.FindEntry(TKey key)
   at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
   at Clave.Expressionify.ExpressionifyVisitor.GetMethodExpression(MethodInfo method) in D:\a\1\s\src\Clave.Expressionify\ExpressionifyVisitor.cs:line 30
   at Clave.Expressionify.ExpressionifyVisitor.VisitMethodCall(MethodCallExpression node) in D:\a\1\s\src\Clave.Expressionify\ExpressionifyVisitor.cs:line 17
   at System.Linq.Expressions.MethodCallExpression.Accept(ExpressionVisitor visitor)
   at System.Dynamic.Utils.ExpressionVisitorUtils.VisitArguments(ExpressionVisitor visitor, IArgumentProvider nodes)
   at System.Linq.Expressions.ExpressionVisitor.VisitArguments(IArgumentProvider nodes)
   at System.Linq.Expressions.ExpressionVisitor.VisitMethodCall(MethodCallExpression node)
   at Clave.Expressionify.ExpressionifyVisitor.VisitMethodCall(MethodCallExpression node) in D:\a\1\s\src\Clave.Expressionify\ExpressionifyVisitor.cs:line 25
   at System.Linq.Expressions.MethodCallExpression.Accept(ExpressionVisitor visitor)
   at Clave.Expressionify.ExpressionableQueryProvider.Visit(Expression exp) in D:\a\1\s\src\Clave.Expressionify\ExpressionableQueryProvider.cs:line 74
   at Clave.Expressionify.ExpressionableQueryProvider.ExecuteQueryAsync[T](Expression expression) in D:\a\1\s\src\Clave.Expressionify\ExpressionableQueryProvider.cs:line 47
   at Clave.Expressionify.ExpressionableQuery`1.GetAsyncEnumerator(CancellationToken cancellationToken) in D:\a\1\s\src\Clave.Expressionify\ExpressionableQuery.cs:line 32
   at System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1.GetAsyncEnumerator()
   at Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync[TSource](IQueryable`1 source, CancellationToken cancellationToken)
...
```

This pull should fixe those issues by changing the **static Dictionary** in the ExpressionifyVisitor class, which is used for read and write access at runtime, to a thread-safe **static ConcurrentDictionary**.