### PR TITLE
Error when code contains null propagation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,12 +60,14 @@ jobs:
           VERSION: ${{ steps.conventional-commits.outputs.version }}
         run: dotnet pack --no-build --include-symbols --configuration release -p:PackageVersion=${{ env.VERSION }} --output ./nugets
 
-      #- name: Push
-      #  run: dotnet nuget push "**/*.nupkg" --api-key ${{ secrets.NUGET }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      - name: Push
+        run: dotnet nuget push "**/*.nupkg" --api-key ${{ secrets.NUGET }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
-      #- name: Tag
-      #  env:
-      #    VERSION: ${{ steps.conventional-commits.outputs.version }}
-      #  run: |
-      #    git tag "v${{ env.VERSION }}" 
-      #    git push origin "v${{ env.VERSION }}"
+      - name: Tag
+        env:
+          VERSION: ${{ steps.conventional-commits.outputs.version }}
+        run: |
+          git commit -am "Created release v${{ env.VERSION }}"
+          git tag "v${{ env.VERSION }}" 
+          git push origin "v${{ env.VERSION }}"
+          git push origin

--- a/src/Clave.Expressionify.Generator/ExpressionifyAnalyzer.cs
+++ b/src/Clave.Expressionify.Generator/ExpressionifyAnalyzer.cs
@@ -14,6 +14,7 @@ namespace Clave.Expressionify.Generator
         public const string StaticId = "EXPR001";
         public const string ExpressionBodyId = "EXPR002";
         public const string PartialClassId = "EXPR003";
+        public const string NullPropagationId = "EXPR004";
 
         public static readonly DiagnosticDescriptor StaticRule = new DiagnosticDescriptor(
             id: StaticId,
@@ -39,17 +40,25 @@ namespace Clave.Expressionify.Generator
             defaultSeverity: DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
+        public static readonly DiagnosticDescriptor NullPropagationRule = new DiagnosticDescriptor(
+            id: NullPropagationId,
+            title: "An expressionify method may not contain a null propagating operator",
+            messageFormat: "Method {0} marked with [Expressionify] may not contain null propagation operator",
+            category: "Syntax",
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
             StaticRule,
             ExpressionBodyRule,
-            PartialClassRule);
+            PartialClassRule,
+            NullPropagationRule);
 
         public override void Initialize(AnalysisContext context)
         {
+            context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.ReportDiagnostics);
-            context.RegisterSyntaxNodeAction(
-                Analyze,
-                SyntaxKind.MethodDeclaration);
+            context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.MethodDeclaration);
         }
 
         private static void Analyze(SyntaxNodeAnalysisContext context)
@@ -74,11 +83,19 @@ namespace Clave.Expressionify.Generator
                     methodDeclaration.Identifier.ToString()));
             }
 
-            if (!methodDeclaration.IsInPartialType())
+            if (methodDeclaration.FindAncestorMissingPartialKeyword() is SyntaxNode typeNode)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
                     PartialClassRule,
-                    methodDeclaration.Ancestors().OfType<ClassDeclarationSyntax>().First().GetLocation()));
+                    typeNode.GetLocation()));
+            }
+
+            if (methodDeclaration.FindNullPropagationNode() is SyntaxNode memberNode)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    NullPropagationRule,
+                    memberNode.GetLocation(),
+                    methodDeclaration.Identifier.ToString()));
             }
         }
     }

--- a/src/Clave.Expressionify.Generator/Internals/Checks.cs
+++ b/src/Clave.Expressionify.Generator/Internals/Checks.cs
@@ -14,12 +14,15 @@ namespace Clave.Expressionify.Generator.Internals
             method.Modifiers.Includes(SyntaxKind.StaticKeyword);
 
         public static bool Includes(this SyntaxTokenList modifiers, SyntaxKind modifier) =>
-            modifiers.Any(m => m.Kind() == modifier);
+            modifiers.Any(m => m.IsKind(modifier));
 
         public static bool HasExpressionBody(this MethodDeclarationSyntax method) =>
             method.ExpressionBody is not null;
 
-        public static bool IsInPartialType(this MethodDeclarationSyntax method) =>
-            method.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault()?.Modifiers.Includes(SyntaxKind.PartialKeyword) ?? false;
+        public static TypeDeclarationSyntax? FindAncestorMissingPartialKeyword(this MethodDeclarationSyntax method) =>
+            method.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault(t => !t.Modifiers.Includes(SyntaxKind.PartialKeyword));
+
+        public static SyntaxNode? FindNullPropagationNode(this MethodDeclarationSyntax method) =>
+            method.DescendantNodes().OfType<ConditionalAccessExpressionSyntax>().FirstOrDefault();
     }
 }

--- a/src/Clave.Expressionify.Generator/Internals/ClassGenerator.cs
+++ b/src/Clave.Expressionify.Generator/Internals/ClassGenerator.cs
@@ -14,7 +14,7 @@ namespace Clave.Expressionify.Generator.Internals
                 .WithModifiers(type.Modifiers)
                 .AddMembers(members.ToArray());
 
-        public static string WithOnlyTheseTypes(this SyntaxNode root, IEnumerable<MemberDeclarationSyntax> members)
+        public static SyntaxNode WithOnlyTheseTypes(this SyntaxNode root, IEnumerable<MemberDeclarationSyntax> members)
         {
             var namespaceName = root.DescendantNodes()
                 .OfType<NamespaceDeclarationSyntax>()
@@ -31,8 +31,7 @@ namespace Clave.Expressionify.Generator.Internals
             return NamespaceDeclaration(namespaceName)
                 .AddUsings(usings)
                 .AddMembers(members.ToArray())
-                .NormalizeWhitespace()
-                .ToFullString();
+                .NormalizeWhitespace();
         }
     }
 }

--- a/tests/Clave.Expressionify.Generator.Tests/AnalyzerTests.cs
+++ b/tests/Clave.Expressionify.Generator.Tests/AnalyzerTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Clave.Expressionify.Generator.ExpressionifyAnalyzer>;
+
+namespace Clave.Expressionify.Generator.Tests
+{
+    public class AnalyzerTests
+    {
+        [Test]
+        public async Task TestNullPropagationMethod()
+        {
+            var test = @"
+                namespace ConsoleApplication1
+                {
+                    public partial class Extensions
+                    {
+                        [Expressionify]
+                        public static int? GetYear(System.DateTime? x) => x?.Year;
+                    }
+                    
+                    [System.AttributeUsage(System.AttributeTargets.Method)]
+                    public class ExpressionifyAttribute : System.Attribute {}
+                }";
+
+            var expected = Verify.Diagnostic(ExpressionifyAnalyzer.NullPropagationRule)
+                .WithSpan("/0/Test0.cs", 7, 75, 7, 82)
+                .WithArguments("GetYear");
+
+            await Verify.VerifyAnalyzerAsync(test, expected);
+        }
+    }
+}

--- a/tests/Clave.Expressionify.Generator.Tests/CodeGeneratorTests.cs
+++ b/tests/Clave.Expressionify.Generator.Tests/CodeGeneratorTests.cs
@@ -34,7 +34,7 @@ namespace Clave.Expressionify.Generator.Tests
     {
         private static System.Linq.Expressions.Expression<System.Func<int, int>> Foo_Expressionify_0 { get; } = (int x) => 8;
     }
-}", Description = "Normal scenario")]
+}", TestName = "Normal scenario")]
         [TestCase(@"namespace ConsoleApplication1;
     public partial class Extensions
     {
@@ -47,7 +47,7 @@ namespace Clave.Expressionify.Generator.Tests
     {
         private static System.Linq.Expressions.Expression<System.Func<int, int>> Foo_Expressionify_0 { get; } = (int x) => 8;
     }
-}", Description = "Nested class")]
+}", TestName = "Nested class")]
         [TestCase(@"namespace ConsoleApplication1
 {
     public partial class Extensions
@@ -72,7 +72,7 @@ namespace Clave.Expressionify.Generator.Tests
             private static System.Linq.Expressions.Expression<System.Func<int, int>> Foo_Expressionify_0 { get; } = (int x) => 8;
         }
     }
-}", Description = "File scoped namespace")]
+}", TestName = "File scoped namespace")]
         public async Task TestGenerator(string source, string generated)
         {
             await VerifyGenerated(source, generated);

--- a/tests/Clave.Expressionify.Generator.Tests/CodeGeneratorTests.cs
+++ b/tests/Clave.Expressionify.Generator.Tests/CodeGeneratorTests.cs
@@ -87,7 +87,7 @@ namespace Clave.Expressionify.Generator.Tests
                     Sources = { source, AttributeCode },
                     GeneratedSources =
                     {
-                        (typeof(ExpressionifySourceGenerator), "Generated_0.cs", SourceText.From(generated, Encoding.UTF8, SourceHashAlgorithm.Sha1)),
+                        (typeof(ExpressionifySourceGenerator), "Test0_expressionify_0.cs", SourceText.From(generated, Encoding.UTF8, SourceHashAlgorithm.Sha1)),
                     },
                 },
             }.RunAsync();


### PR DESCRIPTION
It isn't possible to use null propagation in expression trees, so it can't be used in methods marked with expressionify