### PR TITLE
Added .UseExpressionify() on DbContext-Configuration

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,8 +15,8 @@ Make sure to install the second one properly:
 
 ```xml
   <ItemGroup>
-    <PackageReference Include="Clave.Expressionify" Version="5.0.0" />
-    <PackageReference Include="Clave.Expressionify.Generator" Version="5.0.0">
+    <PackageReference Include="Clave.Expressionify" Version="6.4.0" />
+    <PackageReference Include="Clave.Expressionify.Generator" Version="6.4.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -29,6 +29,8 @@ Make sure to install the second one properly:
 1) Mark the class with the method as `partial`.
 2) Call `.Expressionify()` in your Entity Framework query chain, before using any extension method.
 3) Use the extension method in the query
+
+Alternatively, if you don't want to call `.Expressionify()` on each query, you can also configure your `DbContext` with `.UseExpressionify()`.
 
 ## Example
 
@@ -76,6 +78,21 @@ var users = await db.Users
 +   .Expressionify()
     .Where(user => user.IsOver18())
     .ToListAsync();
+```
+
+## Example configuration
+
+If you configure Expressionify directly on your DbContext, you don't need to call `.Expressionify()` your queries.
+
+```csharp
+public class AppDbContext : DbContext
+{
+    public AppDbContext() : base(new DbContextOptionsBuilder<AppDbContext>()
+                                    .UseSqlServer("ConnectionString")
+                                    .UseExpressionify() // Note that this must be called after configuring your DB provider
+                                    .Options)
+    { }
+}
 ```
 
 ## Upgrading from 3.1 to 5.0

--- a/src/Clave.Expressionify/DbContextOptionsExtensions.cs
+++ b/src/Clave.Expressionify/DbContextOptionsExtensions.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Clave.Expressionify
+{
+    public static class DbContextOptionsExtensions
+    {
+        /// <summary>
+        /// Use Expressionify within your queries.
+        /// Transforms your expressions by replacing any [Expressionify] extension methods with the expressionised versions of those methods.
+        /// </summary>
+        public static DbContextOptionsBuilder<TContext> UseExpressionify<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder)
+            where TContext : DbContext
+        {
+            return (DbContextOptionsBuilder<TContext>)UseExpressionify((DbContextOptionsBuilder)optionsBuilder);
+        }
+
+        /// <summary>
+        /// Use Expressionify within your queries.
+        /// Transforms your expressions by replacing any [Expressionify] extension methods with the expressionised versions of those methods.
+        /// </summary>
+        public static DbContextOptionsBuilder UseExpressionify(this DbContextOptionsBuilder optionsBuilder)
+        {
+            var extension = GetOrCreateExtension(optionsBuilder);
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+            return optionsBuilder;
+        }
+
+        private static ExpressionifyDbContextOptionsExtension GetOrCreateExtension(DbContextOptionsBuilder optionsBuilder) 
+            => optionsBuilder.Options.FindExtension<ExpressionifyDbContextOptionsExtension>()
+            ?? new ExpressionifyDbContextOptionsExtension();
+    }
+}

--- a/src/Clave.Expressionify/ExpressionifyDbContextOptionsExtension.cs
+++ b/src/Clave.Expressionify/ExpressionifyDbContextOptionsExtension.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Clave.Expressionify
+{
+    public class ExpressionifyDbContextOptionsExtension : IDbContextOptionsExtension
+    {
+        public void ApplyServices(IServiceCollection services)
+        {
+            AddDecorator<IQueryTranslationPreprocessorFactory, ExpressionifyQueryTranslationPreprocessorFactory>(services);
+        }
+
+        private static void AddDecorator<TService, TDecorator>(IServiceCollection services)
+        {
+            var descriptor = services.FirstOrDefault(s => s.ServiceType == typeof(TService));
+            if (descriptor == null || descriptor.ImplementationType == null && descriptor.ImplementationFactory == null && descriptor.ImplementationInstance == null)
+                throw new InvalidOperationException($"No {typeof(TService).Name} is configured yet. Please configure a database provider first.");
+
+            // Replace service with decorator. Factory creates the decorator with an instance of the decorated type, based on the original registration.
+            services.Replace(ServiceDescriptor.Describe(
+                descriptor.ServiceType, 
+                provider => ActivatorUtilities.CreateInstance(provider, typeof(TDecorator), GetInstance(provider, descriptor)),
+                descriptor.Lifetime));
+
+            static object GetInstance(IServiceProvider provider, ServiceDescriptor descriptor)
+            {
+                if (descriptor.ImplementationInstance != null)
+                    return descriptor.ImplementationInstance;
+
+                if (descriptor.ImplementationFactory != null)
+                    return descriptor.ImplementationFactory(provider);
+
+                return ActivatorUtilities.GetServiceOrCreateInstance(provider, descriptor.ImplementationType!);
+            }
+        }
+
+        public void Validate(IDbContextOptions options)
+        {
+            // No options to validate
+        }
+
+        public DbContextOptionsExtensionInfo Info => new ExtensionInfo(this);
+
+        private class ExtensionInfo : DbContextOptionsExtensionInfo
+        {
+            public ExtensionInfo(IDbContextOptionsExtension extension) : base(extension)
+            { }
+
+            public override bool IsDatabaseProvider => false;
+            public override string LogFragment => string.Empty;
+
+            public override int GetServiceProviderHashCode()
+            {
+                // As long as there are no options, we can just return 0.
+                // Once options get added, hash them.
+                return 0;
+            }
+
+            public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
+            {
+                // As long as there are no options, we can just return true.
+                // Once options get added, check if they're the same.
+                return true;
+            }
+
+            public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+            {
+                debugInfo["Expressionify:Enabled"] = "true";
+                // Add values of options here
+            }
+        }
+    }
+}

--- a/src/Clave.Expressionify/ExpressionifyQueryTranslationPreprocessor.cs
+++ b/src/Clave.Expressionify/ExpressionifyQueryTranslationPreprocessor.cs
@@ -1,0 +1,22 @@
+﻿using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Clave.Expressionify
+{
+    public class ExpressionifyQueryTranslationPreprocessor : QueryTranslationPreprocessor
+    {
+        readonly QueryTranslationPreprocessor _innerPreprocessor;
+
+        public ExpressionifyQueryTranslationPreprocessor(QueryTranslationPreprocessor innerPreprocessor, QueryTranslationPreprocessorDependencies dependencies, QueryCompilationContext compilationContext) 
+            : base(dependencies, compilationContext)
+        {
+            _innerPreprocessor = innerPreprocessor;
+        }
+
+        public override Expression Process(Expression query)
+        {
+            var expandedExpression = new ExpressionifyVisitor().Visit(query);
+            return _innerPreprocessor.Process(expandedExpression);
+        }
+    }
+}

--- a/src/Clave.Expressionify/ExpressionifyQueryTranslationPreprocessorFactory.cs
+++ b/src/Clave.Expressionify/ExpressionifyQueryTranslationPreprocessorFactory.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Query;
+
+namespace Clave.Expressionify
+{
+    public class ExpressionifyQueryTranslationPreprocessorFactory : IQueryTranslationPreprocessorFactory
+    {
+        private readonly IQueryTranslationPreprocessorFactory _innerFactory;
+        private readonly QueryTranslationPreprocessorDependencies _preprocessorDependencies;
+
+        public ExpressionifyQueryTranslationPreprocessorFactory(IQueryTranslationPreprocessorFactory innerFactory, QueryTranslationPreprocessorDependencies preprocessorDependencies)
+        {
+            _innerFactory = innerFactory;
+            _preprocessorDependencies = preprocessorDependencies;
+        }
+
+        public QueryTranslationPreprocessor Create(QueryCompilationContext queryCompilationContext)
+        {
+            var preprocessor = _innerFactory.Create(queryCompilationContext);
+            return new ExpressionifyQueryTranslationPreprocessor(preprocessor, _preprocessorDependencies, queryCompilationContext);
+        }
+    }
+}

--- a/tests/Clave.Expressionify.Tests/Clave.Expressionify.Tests.csproj
+++ b/tests/Clave.Expressionify.Tests/Clave.Expressionify.Tests.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.4" />
         <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/tests/Clave.Expressionify.Tests/DbContextExtensions/TestDbContext.cs
+++ b/tests/Clave.Expressionify.Tests/DbContextExtensions/TestDbContext.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Clave.Expressionify.Tests.DbContextExtensions
+{
+    public class TestDbContext : DbContext
+    {
+        public TestDbContext(DbContextOptions options) : base(options)
+        { }
+
+        public DbSet<TestEntity> TestEntities { get; set; } = null!;
+    }
+}

--- a/tests/Clave.Expressionify.Tests/DbContextExtensions/TestEntity.cs
+++ b/tests/Clave.Expressionify.Tests/DbContextExtensions/TestEntity.cs
@@ -1,0 +1,8 @@
+﻿namespace Clave.Expressionify.Tests.DbContextExtensions
+{
+    public class TestEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/tests/Clave.Expressionify.Tests/DbContextExtensions/TestEntityExtensions.cs
+++ b/tests/Clave.Expressionify.Tests/DbContextExtensions/TestEntityExtensions.cs
@@ -1,0 +1,8 @@
+﻿namespace Clave.Expressionify.Tests.DbContextExtensions
+{
+    public static partial class TestEntityExtensions
+    {
+        [Expressionify]
+        public static string GetName(this TestEntity testEntity, string prefix) => prefix + " " + testEntity.Name;
+    }
+}

--- a/tests/Clave.Expressionify.Tests/DbContextExtensions/Tests.cs
+++ b/tests/Clave.Expressionify.Tests/DbContextExtensions/Tests.cs
@@ -1,0 +1,62 @@
+﻿using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Clave.Expressionify.Tests.DbContextExtensions
+{
+    public class Tests
+    {
+        [Test]
+        public void UseExpressionifyInConfig_ExpandsExpression_CanTranslate()
+        {
+            using var dbContext = new TestDbContext(GetOptions(useExpressionify: true));
+            var query = dbContext.TestEntities.Select(e => e.GetName("oh hi"));
+
+            var sql = query.ToQueryString();
+            sql.ShouldStartWith("SELECT ('oh hi' || ' ') || \"t\".\"Name\"");
+        }
+
+        [Test]
+        public void UseExpressionifyInQuery_ExpandsExpression_CanTranslate()
+        {
+            using var dbContext = new TestDbContext(GetOptions(useExpressionify: false));
+            var query = dbContext.TestEntities.Expressionify().Select(e => e.GetName("oh hi"));
+
+            var sql = query.ToQueryString();
+            sql.ShouldStartWith("SELECT 'oh hi ' || \"t\".\"Name\"");
+        }
+
+        [Test]
+        public void UseExpressionifyInQueryAndConfig_ExpandsExpression_CanTranslate()
+        {
+            using var dbContext = new TestDbContext(GetOptions(useExpressionify: true));
+            var query = dbContext.TestEntities.Expressionify().Select(e => e.GetName("oh hi"));
+
+            var sql = query.ToQueryString();
+            sql.ShouldStartWith("SELECT 'oh hi ' || \"t\".\"Name\"");
+        }
+
+        [Test]
+        public void DontUseExpressionify_EfSelectsWholeEntity()
+        {
+            // This is basically a self-test of the test setup. EF should select the whole entity here, instead of the "optimized" version where
+            // the concatenation is done in the statement and only the required name is selected
+            using var dbContext = new TestDbContext(GetOptions(useExpressionify: false));
+            var query = dbContext.TestEntities.Select(e => e.GetName("oh hi"));
+
+            var sql = query.ToQueryString();
+            sql.ShouldStartWith("SELECT \"t\".\"Id\", \"t\".\"Name\"");
+        }
+
+        private DbContextOptions GetOptions(bool useExpressionify)
+        {
+            var builder = new DbContextOptionsBuilder<TestDbContext>().UseSqlite("DataSource=:memory:");
+
+            if (useExpressionify)
+                builder.UseExpressionify();
+
+            return builder.Options;
+        }
+    }
+}


### PR DESCRIPTION
This partially implements #6.

With this PR you can just configure Expressionify once on your DbContext (via `.UseExpressionify()`), removing the requirement to always call `.Expressionify()` on each query.