### PR TITLE
feat: Added support for the EF compiled query cache when using .UseExpressionify()

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -97,12 +97,12 @@ var users = await db.Users
 
 ### Query caching
 
-When configuring the DbContext with `.UseExpressionify()`, Expressionify is called on each query execution.
-
-You can use the EntityFramework compiled query cache, which calls Expressionify only while EntityFramework caches the query, but it comes with [some limitations](#query-caching-limitations).
+When configuring the DbContext with `.UseExpressionify()`, Expressionify tries to use the EntityFramework query cache by default. This way the expression tree is only processed once and then cached. 
+However, this comes with [some limitations](#query-caching-limitations). Expressionify throws an exception if your query cannot be cached. 
+To fix this, you either have to call `.Expressionify()` explicitly on the query or disable query caching:
 
 ```csharp
-.UseExpressionify(o => o.WithEvaluationMode(ExpressionEvaluationMode.Cached));
+.UseExpressionify(o => o.WithEvaluationMode(ExpressionEvaluationMode.Always));
 ```
 
 ## Upgrading from 3.1 to 5.0

--- a/Readme.md
+++ b/Readme.md
@@ -102,7 +102,7 @@ However, this comes with [some limitations](#query-caching-limitations). Express
 To fix this, you either have to call `.Expressionify()` explicitly on the query or disable query caching:
 
 ```csharp
-.UseExpressionify(o => o.WithEvaluationMode(ExpressionEvaluationMode.Always));
+.UseExpressionify(o => o.WithEvaluationMode(ExpressionEvaluationMode.FullCompatibilityButSlow));
 ```
 
 ## Upgrading from 3.1 to 5.0
@@ -159,34 +159,34 @@ Examples:
 ```csharp
 public static partial class Extensions {
    // Example: users.Where(u => u.IsOver18())
-   // ✔ OK for ExpressionEvaluationMode.Always
-   // ✔ OK for ExpressionEvaluationMode.Cached
+   // ✔ OK for ExpressionEvaluationMode.FullCompatibilityButSlow
+   // ✔ OK for ExpressionEvaluationMode.LimitedCompatibilityButCached
    // The expression can be translated to SQL without introducing new parameters
    [Expressionify]
    public static bool IsOver18(this User user)
        => user.DateOfBirth < DateTime.Now.AddYears(-18);
 
    // Example: users.Where(u => u.IsOlderThan(18))
-   // ✔ OK for ExpressionEvaluationMode.Always
-   // ✔ OK for ExpressionEvaluationMode.Cached
+   // ✔ OK for ExpressionEvaluationMode.FullCompatibilityButSlow
+   // ✔ OK for ExpressionEvaluationMode.LimitedCompatibilityButCached
    // The parameter 'years' is already present in the query itself. No new parameters are introduced when expanding the query.
    [Expressionify]
    public static bool IsOlderThan(this User user, int years)
        => user.DateOfBirth < DateTime.Now.AddYears(-years);
 
    // Example: users.Where(u => u.WasAddedRecently())
-   // ✔ OK for ExpressionEvaluationMode.Always
-   // ❌ Not ok for ExpressionEvaluationMode.Cached
-   // ✔ OK for ExpressionEvaluationMode.Cached when explicitly expanding the query with 'query.Expressionify()'
+   // ✔ OK for ExpressionEvaluationMode.FullCompatibilityButSlow
+   // ❌ Not ok for ExpressionEvaluationMode.LimitedCompatibilityButCached
+   // ✔ OK for ExpressionEvaluationMode.LimitedCompatibilityButCached when explicitly expanding the query with 'query.Expressionify()'
    // 'TimeProvider.UtcNow' is a new parameter that is not known in the query before calling '.Expressionify()'.
    [Expressionify]
    public static bool WasAddedRecently(this User user)
        => user.Created >= TimeProvider.UtcNow.AddDays(-1);
 
    // Example: users.Select(u => u.ToTestView(null))
-   // ✔ OK for ExpressionEvaluationMode.Always
-   // ❌ Not ok for ExpressionEvaluationMode.Cached
-   // ✔ OK for ExpressionEvaluationMode.Cached when explicitly expanding the query with 'query.Expressionify()'
+   // ✔ OK for ExpressionEvaluationMode.FullCompatibilityButSlow
+   // ❌ Not ok for ExpressionEvaluationMode.LimitedCompatibilityButCached
+   // ✔ OK for ExpressionEvaluationMode.LimitedCompatibilityButCached when explicitly expanding the query with 'query.Expressionify()'
    // With the input 'null' on the address, the expression 'address == null ? null : address.Street' gets replaced with a
    // new parameter for the value 'null'.
    [Expressionify]

--- a/src/Clave.Expressionify/DbContextOptionsExtensions.cs
+++ b/src/Clave.Expressionify/DbContextOptionsExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Clave.Expressionify
@@ -9,25 +10,27 @@ namespace Clave.Expressionify
         /// Use Expressionify within your queries.
         /// Transforms your expressions by replacing any [Expressionify] extension methods with the expressionised versions of those methods.
         /// </summary>
-        public static DbContextOptionsBuilder<TContext> UseExpressionify<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder)
+        public static DbContextOptionsBuilder<TContext> UseExpressionify<TContext>(this DbContextOptionsBuilder<TContext> optionsBuilder, Action<ExpressionifyDbContextOptionsBuilder>? expressionifyOptionsAction = null)
             where TContext : DbContext
         {
-            return (DbContextOptionsBuilder<TContext>)UseExpressionify((DbContextOptionsBuilder)optionsBuilder);
+            return (DbContextOptionsBuilder<TContext>)UseExpressionify((DbContextOptionsBuilder)optionsBuilder, expressionifyOptionsAction);
         }
 
         /// <summary>
         /// Use Expressionify within your queries.
         /// Transforms your expressions by replacing any [Expressionify] extension methods with the expressionised versions of those methods.
         /// </summary>
-        public static DbContextOptionsBuilder UseExpressionify(this DbContextOptionsBuilder optionsBuilder)
+        public static DbContextOptionsBuilder UseExpressionify(this DbContextOptionsBuilder optionsBuilder, Action<ExpressionifyDbContextOptionsBuilder>? expressionifyOptionsAction = null)
         {
             var extension = GetOrCreateExtension(optionsBuilder);
             ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
 
+            expressionifyOptionsAction?.Invoke(new ExpressionifyDbContextOptionsBuilder(optionsBuilder));
+
             return optionsBuilder;
         }
 
-        private static ExpressionifyDbContextOptionsExtension GetOrCreateExtension(DbContextOptionsBuilder optionsBuilder) 
+        private static ExpressionifyDbContextOptionsExtension GetOrCreateExtension(DbContextOptionsBuilder optionsBuilder)
             => optionsBuilder.Options.FindExtension<ExpressionifyDbContextOptionsExtension>()
             ?? new ExpressionifyDbContextOptionsExtension();
     }

--- a/src/Clave.Expressionify/ExpressionEvaluationMode.cs
+++ b/src/Clave.Expressionify/ExpressionEvaluationMode.cs
@@ -1,0 +1,15 @@
+﻿namespace Clave.Expressionify;
+
+public enum ExpressionEvaluationMode
+{
+    /// <summary> Always check for <code>[Expressionify]</code> extension methods when executing a query. </summary>
+    Always = 0,
+
+    /// <summary>
+    /// Use the EF compiled query cache and only check for <code>[Expressionify]</code> extension methods when a query gets cached.<br/>
+    /// Not all queries work with this mode enabled. For those queries who don't, you get an <code>InvalidOperationException</code> and you need
+    /// to call <code>query.Expressionify()</code> explicitly.<br/>
+    /// This is the case for <code>[Expressionify]</code>-methods that introduce new query-parameters either directly, or indirectly via an EF optimization.
+    /// </summary>
+    Cached = 1
+}

--- a/src/Clave.Expressionify/ExpressionEvaluationMode.cs
+++ b/src/Clave.Expressionify/ExpressionEvaluationMode.cs
@@ -3,7 +3,7 @@
 public enum ExpressionEvaluationMode
 {
     /// <summary> Always check for <code>[Expressionify]</code> extension methods when executing a query. </summary>
-    Always = 0,
+    FullCompatibilityButSlow = 0,
 
     /// <summary>
     /// Use the EF compiled query cache and only check for <code>[Expressionify]</code> extension methods when a query gets cached.<br/>
@@ -11,5 +11,5 @@ public enum ExpressionEvaluationMode
     /// to call <code>query.Expressionify()</code> explicitly.<br/>
     /// This is the case for <code>[Expressionify]</code>-methods that introduce new query-parameters either directly, or indirectly via an EF optimization.
     /// </summary>
-    Cached = 1
+    LimitedCompatibilityButCached = 1
 }

--- a/src/Clave.Expressionify/ExpressionifyDbContextOptionsBuilder.cs
+++ b/src/Clave.Expressionify/ExpressionifyDbContextOptionsBuilder.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Clave.Expressionify;
+
+public class ExpressionifyDbContextOptionsBuilder
+{
+    private readonly DbContextOptionsBuilder _optionsBuilder;
+
+    internal ExpressionifyDbContextOptionsBuilder(DbContextOptionsBuilder optionsBuilder) => _optionsBuilder = optionsBuilder;
+
+    public ExpressionifyDbContextOptionsBuilder WithEvaluationMode(ExpressionEvaluationMode mode) => WithOption(e => e.WithEvaluationMode(mode));
+
+    /// <summary>
+    ///     Sets an option by cloning the extension used to store the settings. This ensures the builder
+    ///     does not modify options that are already in use elsewhere.
+    /// </summary>
+    /// <param name="setAction">An action to set the option.</param>
+    /// <returns>The same builder instance so that multiple calls can be chained.</returns>
+    private ExpressionifyDbContextOptionsBuilder WithOption(Func<ExpressionifyDbContextOptionsExtension, ExpressionifyDbContextOptionsExtension> setAction)
+    {
+        var extension = setAction(_optionsBuilder.Options.FindExtension<ExpressionifyDbContextOptionsExtension>()!);
+        ((IDbContextOptionsBuilderInfrastructure)_optionsBuilder).AddOrUpdateExtension(extension);
+
+        return this;
+    }
+}

--- a/src/Clave.Expressionify/ExpressionifyDbContextOptionsExtension.cs
+++ b/src/Clave.Expressionify/ExpressionifyDbContextOptionsExtension.cs
@@ -20,7 +20,7 @@ namespace Clave.Expressionify
         }
         
         public DbContextOptionsExtensionInfo Info => new ExtensionInfo(this);
-        public ExpressionEvaluationMode EvaluationMode { get; private set; } = ExpressionEvaluationMode.Always;
+        public ExpressionEvaluationMode EvaluationMode { get; private set; } = ExpressionEvaluationMode.Cached;
 
         public void ApplyServices(IServiceCollection services)
         {

--- a/src/Clave.Expressionify/ExpressionifyDbContextOptionsExtension.cs
+++ b/src/Clave.Expressionify/ExpressionifyDbContextOptionsExtension.cs
@@ -20,14 +20,16 @@ namespace Clave.Expressionify
         }
         
         public DbContextOptionsExtensionInfo Info => new ExtensionInfo(this);
-        public ExpressionEvaluationMode EvaluationMode { get; private set; } = ExpressionEvaluationMode.Cached;
+        public ExpressionEvaluationMode EvaluationMode { get; private set; } = ExpressionEvaluationMode.LimitedCompatibilityButCached;
 
         public void ApplyServices(IServiceCollection services)
         {
-            if (EvaluationMode == ExpressionEvaluationMode.Always)
+            if (EvaluationMode == ExpressionEvaluationMode.FullCompatibilityButSlow)
                 AddDecorator<IQueryCompiler, ExpressionableQueryCompiler>(services);
-            else if (EvaluationMode == ExpressionEvaluationMode.Cached)
+
+            else if (EvaluationMode == ExpressionEvaluationMode.LimitedCompatibilityButCached)
                 AddDecorator<IQueryTranslationPreprocessorFactory, ExpressionifyQueryTranslationPreprocessorFactory>(services);
+
             else
                 throw new NotSupportedException($"Unsupported {nameof(EvaluationMode)}");
         }

--- a/src/Clave.Expressionify/ExpressionifyQueryTranslationPreprocessor.cs
+++ b/src/Clave.Expressionify/ExpressionifyQueryTranslationPreprocessor.cs
@@ -25,13 +25,15 @@ namespace Clave.Expressionify
             query = visitor.Visit(query);
 
             if (visitor.HasReplacedCalls)
-               EnsureNoNewParametersExist(query);
+               query = EvaluateExpression(query);
 
             return _innerPreprocessor.Process(query);
         }
 
-        private void EnsureNoNewParametersExist(Expression query)
+        private Expression EvaluateExpression(Expression query)
         {
+            // 1) Ensure that no new parameters are introduced when creating the query
+            // 2) This expression visitor also makes slight optimzations, like replacing evaluatable expressions.
             var visitor = new ParameterExtractingExpressionVisitor(
                 Dependencies.EvaluatableExpressionFilter,
                 new ThrowOnParameterAccess(),
@@ -41,7 +43,7 @@ namespace Clave.Expressionify
                 parameterize: true,
                 generateContextAccessors: false);
 
-            visitor.ExtractParameters(query);
+            return visitor.ExtractParameters(query);
         }
 
         private class ThrowOnParameterAccess : IParameterValues

--- a/src/Clave.Expressionify/ExpressionifyQueryTranslationPreprocessor.cs
+++ b/src/Clave.Expressionify/ExpressionifyQueryTranslationPreprocessor.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Clave.Expressionify
+{
+    public class ExpressionifyQueryTranslationPreprocessor : QueryTranslationPreprocessor
+    {
+        private readonly QueryTranslationPreprocessor _innerPreprocessor;
+
+        public ExpressionifyQueryTranslationPreprocessor(
+            QueryTranslationPreprocessor innerPreprocessor, 
+            QueryTranslationPreprocessorDependencies dependencies,
+            QueryCompilationContext compilationContext)
+            : base(dependencies, compilationContext)
+        {
+            _innerPreprocessor = innerPreprocessor;
+        }
+
+        public override Expression Process(Expression query)
+        {
+            var visitor = new ExpressionifyVisitor();
+            query = visitor.Visit(query);
+
+            if (visitor.HasReplacedCalls)
+               EnsureNoNewParametersExist(query);
+
+            return _innerPreprocessor.Process(query);
+        }
+
+        private void EnsureNoNewParametersExist(Expression query)
+        {
+            var visitor = new ParameterExtractingExpressionVisitor(
+                Dependencies.EvaluatableExpressionFilter,
+                new ThrowOnParameterAccess(),
+                QueryCompilationContext.ContextType,
+                QueryCompilationContext.Model,
+                QueryCompilationContext.Logger,
+                parameterize: true,
+                generateContextAccessors: false);
+
+            visitor.ExtractParameters(query);
+        }
+
+        private class ThrowOnParameterAccess : IParameterValues
+        {
+            public void AddParameter(string name, object? value)
+                => throw new InvalidOperationException(
+                    "Adding parameters in a cached query context is not allowed. Explicitly call .Expressionify() on the query or use ExpressionEvaluationMode.Always.");
+        
+            public IReadOnlyDictionary<string, object?> ParameterValues
+                => throw new InvalidOperationException(
+                    "Accessing parameters in a cached query context is not allowed. Explicitly call .Expressionify() on the query or use ExpressionEvaluationMode.Always.");
+        }
+    }
+}

--- a/src/Clave.Expressionify/ExpressionifyQueryTranslationPreprocessorFactory.cs
+++ b/src/Clave.Expressionify/ExpressionifyQueryTranslationPreprocessorFactory.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.EntityFrameworkCore.Query;
+
+namespace Clave.Expressionify;
+
+public class ExpressionifyQueryTranslationPreprocessorFactory : IQueryTranslationPreprocessorFactory
+{
+    private readonly IQueryTranslationPreprocessorFactory _innerFactory;
+    private readonly QueryTranslationPreprocessorDependencies _preprocessorDependencies;
+
+    public ExpressionifyQueryTranslationPreprocessorFactory(IQueryTranslationPreprocessorFactory innerFactory, QueryTranslationPreprocessorDependencies preprocessorDependencies)
+    {
+        _innerFactory = innerFactory;
+        _preprocessorDependencies = preprocessorDependencies;
+    }
+
+    public QueryTranslationPreprocessor Create(QueryCompilationContext queryCompilationContext)
+    {
+        var preprocessor = _innerFactory.Create(queryCompilationContext);
+        return new ExpressionifyQueryTranslationPreprocessor(preprocessor, _preprocessorDependencies, queryCompilationContext);
+    }
+}

--- a/src/Clave.Expressionify/ExpressionifyVisitor.cs
+++ b/src/Clave.Expressionify/ExpressionifyVisitor.cs
@@ -13,10 +13,13 @@ namespace Clave.Expressionify
 
         private readonly Dictionary<ParameterExpression, Expression> _replacements = new Dictionary<ParameterExpression, Expression>();
 
+        internal bool HasReplacedCalls { get; private set; }
+
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
             if (GetMethodExpression(node.Method) is LambdaExpression expression)
             {
+                HasReplacedCalls = true;
                 RegisterReplacementParameters(node.Arguments, expression);
                 var result = Visit(expression.Body);
                 UnregisterReplacementParameters(expression);

--- a/tests/Clave.Expressionify.Tests/DbContextExtensions/TestEntity.cs
+++ b/tests/Clave.Expressionify.Tests/DbContextExtensions/TestEntity.cs
@@ -6,5 +6,23 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
     {
         public int Id { get; set; }
         public string Name { get; set; }
+        public DateTime Created { get; set; }
+    }
+
+    public class TestAddress
+    {
+        public string City { get; set; }
+        public string Street { get; set; }
+    }
+
+    public class TestView
+    {
+        public string Name { get; set; }
+        public string? Street { get; set; }
+    }
+
+    public static class TestTimeProvider
+    {
+        public static DateTime UtcNow => new(2022, 3, 4, 5, 6, 7);
     }
 }

--- a/tests/Clave.Expressionify.Tests/DbContextExtensions/TestEntityExtensions.cs
+++ b/tests/Clave.Expressionify.Tests/DbContextExtensions/TestEntityExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Clave.Expressionify.Tests.DbContextExtensions
+﻿namespace Clave.Expressionify.Tests.DbContextExtensions
 {
     public static partial class TestEntityExtensions
     {
@@ -8,7 +6,20 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
         public static string GetName(this TestEntity testEntity, string prefix) => prefix + " " + testEntity.Name;
 
         [Expressionify]
+        public static bool NameEquals(this TestEntity testEntity, string name) => testEntity.Name == name;
+
+        [Expressionify]
+        public static bool IsJohnDoe(this TestEntity testEntity) => testEntity.Name == "John Doe";
+
+        [Expressionify]
         public static bool IsSomething(this TestEntity testEntity) => testEntity.Name == Name;
+
+        [Expressionify]
+        public static bool IsRecent(this TestEntity testEntity) => testEntity.Created > TestTimeProvider.UtcNow.AddDays(-1);
+
+        [Expressionify]
+        public static TestView ToTestView(this TestEntity testEntity, TestAddress? address)
+            => new() { Name = testEntity.Name, Street = address == null ? null : address.Street };
 
         public static string Name => "Something";
     }

--- a/tests/Clave.Expressionify.Tests/DbContextExtensions/Tests.cs
+++ b/tests/Clave.Expressionify.Tests/DbContextExtensions/Tests.cs
@@ -132,6 +132,19 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
             queryA.ToQueryString().ShouldBe(queryB.ToQueryString());
         }
 
+        [TestCase(ExpressionEvaluationMode.Always)]
+        [TestCase(ExpressionEvaluationMode.Cached)]
+        public void UseExpressionify_ShouldProduceSameOutputAsExpressionify_InAllModes(ExpressionEvaluationMode mode)
+        {
+            // Note: when not using the result of ParameterExtractingExpressionVisitor, the Cached mode returns another query with an additional concat (which would be unintended)
+
+            using var dbContext = new TestDbContext(GetOptions(o => o.WithEvaluationMode(mode)));
+            var queryA = dbContext.TestEntities.Select(e => e.GetName("oh hi"));
+            var queryB = dbContext.TestEntities.Expressionify().Select(e => e.GetName("oh hi"));
+
+            queryA.ToQueryString().ShouldBe(queryB.ToQueryString());
+        }
+
         [Test]
         public void UseExpressionify_EvaluationModeAlways_ShouldHandleEvaluatableExpressions()
         {

--- a/tests/Clave.Expressionify.Tests/DbContextExtensions/Tests.cs
+++ b/tests/Clave.Expressionify.Tests/DbContextExtensions/Tests.cs
@@ -62,8 +62,8 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
             query.ToQueryString().ShouldBe($".param set @__Name_0 'Something'{Environment.NewLine}{Environment.NewLine}SELECT \"t\".\"Id\", \"t\".\"Created\", \"t\".\"Name\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"{Environment.NewLine}WHERE \"t\".\"Name\" = @__Name_0");
         }
 
-        [TestCase(ExpressionEvaluationMode.Always)]
-        [TestCase(ExpressionEvaluationMode.Cached)]
+        [TestCase(ExpressionEvaluationMode.FullCompatibilityButSlow)]
+        [TestCase(ExpressionEvaluationMode.LimitedCompatibilityButCached)]
         public void UseExpressionify_ShouldHandleConstants(ExpressionEvaluationMode mode)
         {
             var name = "oh hi";
@@ -73,8 +73,8 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
             query.ToQueryString().ShouldBe($"SELECT \"t\".\"Id\", \"t\".\"Created\", \"t\".\"Name\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"{Environment.NewLine}WHERE \"t\".\"Name\" = 'John Doe'");
         }
 
-        [TestCase(ExpressionEvaluationMode.Always)]
-        [TestCase(ExpressionEvaluationMode.Cached)]
+        [TestCase(ExpressionEvaluationMode.FullCompatibilityButSlow)]
+        [TestCase(ExpressionEvaluationMode.LimitedCompatibilityButCached)]
         public void UseExpressionify_ShouldHandleWhereWithParameters(ExpressionEvaluationMode mode)
         {
             var name = "oh hi";
@@ -87,7 +87,7 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
         [Test]
         public void UseExpressionify_EvaluationModeAlways_ShouldHandleWhereWithNewParameters()
         {
-            using var dbContext = new TestDbContext(GetOptions(optionsAction: o => o.WithEvaluationMode(ExpressionEvaluationMode.Always)));
+            using var dbContext = new TestDbContext(GetOptions(optionsAction: o => o.WithEvaluationMode(ExpressionEvaluationMode.FullCompatibilityButSlow)));
             var query = dbContext.TestEntities.Where(e => e.IsSomething());
 
             query.ToQueryString().ShouldBe($".param set @__Name_0 'Something'{Environment.NewLine}{Environment.NewLine}SELECT \"t\".\"Id\", \"t\".\"Created\", \"t\".\"Name\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"{Environment.NewLine}WHERE \"t\".\"Name\" = @__Name_0");
@@ -96,7 +96,7 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
         [Test]
         public void UseExpressionify_EvaluationModeAlways_ShouldHandleWhereWithExternalServices()
         {
-            using var dbContext = new TestDbContext(GetOptions(optionsAction: o => o.WithEvaluationMode(ExpressionEvaluationMode.Always)));
+            using var dbContext = new TestDbContext(GetOptions(optionsAction: o => o.WithEvaluationMode(ExpressionEvaluationMode.FullCompatibilityButSlow)));
             var query = dbContext.TestEntities.Where(e => e.IsRecent());
 
             query.ToQueryString().ShouldBe($".param set @__AddDays_0 '2022-03-03 05:06:07'{Environment.NewLine}{Environment.NewLine}SELECT \"t\".\"Id\", \"t\".\"Created\", \"t\".\"Name\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"{Environment.NewLine}WHERE \"t\".\"Created\" > @__AddDays_0");
@@ -105,7 +105,7 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
         [Test]
         public void UseExpressionify_EvaluationModeCached_CannotHandleNewParameters()
         {
-            using var dbContext = new TestDbContext(GetOptions(optionsAction: o => o.WithEvaluationMode(ExpressionEvaluationMode.Cached)));
+            using var dbContext = new TestDbContext(GetOptions(optionsAction: o => o.WithEvaluationMode(ExpressionEvaluationMode.LimitedCompatibilityButCached)));
             var query = dbContext.TestEntities.Where(e => e.IsSomething());
 
             var exception = Should.Throw<InvalidOperationException>(() => query.ToQueryString());
@@ -115,7 +115,7 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
         [Test]
         public void UseExpressionify_EvaluationModeCached_CannotHandleParametersFromExternalServices()
         {
-            using var dbContext = new TestDbContext(GetOptions(optionsAction: o => o.WithEvaluationMode(ExpressionEvaluationMode.Cached)));
+            using var dbContext = new TestDbContext(GetOptions(optionsAction: o => o.WithEvaluationMode(ExpressionEvaluationMode.LimitedCompatibilityButCached)));
             var query = dbContext.TestEntities.Where(e => e.IsSomething());
 
             var exception = Should.Throw<InvalidOperationException>(() => query.ToQueryString());
@@ -132,8 +132,8 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
             queryA.ToQueryString().ShouldBe(queryB.ToQueryString());
         }
 
-        [TestCase(ExpressionEvaluationMode.Always)]
-        [TestCase(ExpressionEvaluationMode.Cached)]
+        [TestCase(ExpressionEvaluationMode.FullCompatibilityButSlow)]
+        [TestCase(ExpressionEvaluationMode.LimitedCompatibilityButCached)]
         public void UseExpressionify_ShouldProduceSameOutputAsExpressionify_InAllModes(ExpressionEvaluationMode mode)
         {
             // Note: when not using the result of ParameterExtractingExpressionVisitor, the Cached mode returns another query with an additional concat (which would be unintended)
@@ -148,7 +148,7 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
         [Test]
         public void UseExpressionify_EvaluationModeAlways_ShouldHandleEvaluatableExpressions()
         {
-            using var dbContext = new TestDbContext(GetOptions(o => o.WithEvaluationMode(ExpressionEvaluationMode.Always)));
+            using var dbContext = new TestDbContext(GetOptions(o => o.WithEvaluationMode(ExpressionEvaluationMode.FullCompatibilityButSlow)));
             var query = dbContext.TestEntities.Select(e => e.ToTestView(null));
 
             query.ToQueryString().ShouldBe($"SELECT \"t\".\"Name\", NULL AS \"Street\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"");
@@ -157,15 +157,15 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
         [Test]
         public void UseExpressionify_EvaluationModeCached_CannotHandleEvaluatableExpressions()
         {
-            using var dbContext = new TestDbContext(GetOptions(o => o.WithEvaluationMode(ExpressionEvaluationMode.Cached)));
+            using var dbContext = new TestDbContext(GetOptions(o => o.WithEvaluationMode(ExpressionEvaluationMode.LimitedCompatibilityButCached)));
             var query = dbContext.TestEntities.Select(e => e.ToTestView(null));
 
             var exception = Should.Throw<InvalidOperationException>(() => query.ToQueryString());
             exception.Message.ShouldBe("Accessing parameters in a cached query context is not allowed. Explicitly call .Expressionify() on the query or use ExpressionEvaluationMode.Always.");
         }
 
-        [TestCase(ExpressionEvaluationMode.Always)]
-        [TestCase(ExpressionEvaluationMode.Cached)]
+        [TestCase(ExpressionEvaluationMode.FullCompatibilityButSlow)]
+        [TestCase(ExpressionEvaluationMode.LimitedCompatibilityButCached)]
         public void UseExpressionify_WithEvaluationMode_SetsEvaluationMode(ExpressionEvaluationMode mode)
         {
             var options = GetOptions(o => o.WithEvaluationMode(mode));
@@ -186,7 +186,7 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
             var debugInfo = new Dictionary<string, string>();
             extension.Info.PopulateDebugInfo(debugInfo);
             
-            debugInfo["Expressionify:EvaluationMode"].ShouldBe(ExpressionEvaluationMode.Always.ToString());
+            debugInfo["Expressionify:EvaluationMode"].ShouldBe(ExpressionEvaluationMode.FullCompatibilityButSlow.ToString());
         }
 
         private DbContextOptions GetOptions(Action<ExpressionifyDbContextOptionsBuilder>? optionsAction = null, bool useExpressionify = true)

--- a/tests/Clave.Expressionify.Tests/DbContextExtensions/Tests.cs
+++ b/tests/Clave.Expressionify.Tests/DbContextExtensions/Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using NUnit.Framework;
@@ -11,7 +12,7 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
         [Test]
         public void UseExpressionifyInConfig_ExpandsExpression_CanTranslate()
         {
-            using var dbContext = new TestDbContext(GetOptions(useExpressionify: true));
+            using var dbContext = new TestDbContext(GetOptions());
             var query = dbContext.TestEntities.Select(e => e.GetName("oh hi"));
 
             var sql = query.ToQueryString();
@@ -31,11 +32,12 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
         [Test]
         public void UseExpressionifyInQueryAndConfig_ExpandsExpression_CanTranslate()
         {
-            using var dbContext = new TestDbContext(GetOptions(useExpressionify: true));
-            var query = dbContext.TestEntities.Expressionify().Select(e => e.GetName("oh hi"));
+            using var dbContext = new TestDbContext(GetOptions());
+            var prefix = "oh hi";
+            var query = dbContext.TestEntities.Expressionify().Select(e => e.GetName(prefix));
 
             var sql = query.ToQueryString();
-            sql.ShouldStartWith("SELECT 'oh hi ' || \"t\".\"Name\"");
+            sql.ShouldBe($".param set @__p_0 'oh hi '{Environment.NewLine}{Environment.NewLine}SELECT @__p_0 || \"t\".\"Name\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"");
         }
 
         [Test]
@@ -44,46 +46,142 @@ namespace Clave.Expressionify.Tests.DbContextExtensions
             // This is basically a self-test of the test setup. EF should select the whole entity here, instead of the "optimized" version where
             // the concatenation is done in the statement and only the required name is selected
             using var dbContext = new TestDbContext(GetOptions(useExpressionify: false));
-            var query = dbContext.TestEntities.Select(e => e.GetName("oh hi"));
+            var prefix = "oh hi";
+            var query = dbContext.TestEntities.Select(e => e.GetName(prefix));
 
             var sql = query.ToQueryString();
-            sql.ShouldStartWith("SELECT \"t\".\"Id\", \"t\".\"Name\"");
+            sql.ShouldStartWith("SELECT \"t\".\"Id\", \"t\".\"Created\", \"t\".\"Name\"");
         }
 
         [Test]
-        public void Expressionify_ShouldHandleWhereWithParameters()
+        public void Expressionify_ShouldHandleWhereWithParameters_AfterExpansion()
         {
-            using var dbContext = new TestDbContext(GetOptions(useExpressionify: true));
+            using var dbContext = new TestDbContext(GetOptions());
             var query = dbContext.TestEntities.Expressionify().Where(e => e.IsSomething());
 
-            query.ToQueryString().ShouldBe($".param set @__Name_0 'Something'{Environment.NewLine}{Environment.NewLine}SELECT \"t\".\"Id\", \"t\".\"Name\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"{Environment.NewLine}WHERE \"t\".\"Name\" = @__Name_0");
+            query.ToQueryString().ShouldBe($".param set @__Name_0 'Something'{Environment.NewLine}{Environment.NewLine}SELECT \"t\".\"Id\", \"t\".\"Created\", \"t\".\"Name\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"{Environment.NewLine}WHERE \"t\".\"Name\" = @__Name_0");
+        }
+
+        [TestCase(ExpressionEvaluationMode.Always)]
+        [TestCase(ExpressionEvaluationMode.Cached)]
+        public void UseExpressionify_ShouldHandleConstants(ExpressionEvaluationMode mode)
+        {
+            var name = "oh hi";
+            using var dbContext = new TestDbContext(GetOptions(o => o.WithEvaluationMode(mode)));
+            var query = dbContext.TestEntities.Where(e => e.IsJohnDoe());
+
+            query.ToQueryString().ShouldBe($"SELECT \"t\".\"Id\", \"t\".\"Created\", \"t\".\"Name\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"{Environment.NewLine}WHERE \"t\".\"Name\" = 'John Doe'");
+        }
+
+        [TestCase(ExpressionEvaluationMode.Always)]
+        [TestCase(ExpressionEvaluationMode.Cached)]
+        public void UseExpressionify_ShouldHandleWhereWithParameters(ExpressionEvaluationMode mode)
+        {
+            var name = "oh hi";
+            using var dbContext = new TestDbContext(GetOptions(o => o.WithEvaluationMode(mode)));
+            var query = dbContext.TestEntities.Where(e => e.NameEquals(name));
+
+            query.ToQueryString().ShouldBe($".param set @__name_0 'oh hi'{Environment.NewLine}{Environment.NewLine}SELECT \"t\".\"Id\", \"t\".\"Created\", \"t\".\"Name\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"{Environment.NewLine}WHERE \"t\".\"Name\" = @__name_0");
         }
 
         [Test]
-        public void UseExpressionify_ShouldHandleWhereWithParameters()
+        public void UseExpressionify_EvaluationModeAlways_ShouldHandleWhereWithNewParameters()
         {
-            using var dbContext = new TestDbContext(GetOptions(useExpressionify: true));
+            using var dbContext = new TestDbContext(GetOptions(optionsAction: o => o.WithEvaluationMode(ExpressionEvaluationMode.Always)));
             var query = dbContext.TestEntities.Where(e => e.IsSomething());
 
-            query.ToQueryString().ShouldBe($".param set @__Name_0 'Something'{Environment.NewLine}{Environment.NewLine}SELECT \"t\".\"Id\", \"t\".\"Name\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"{Environment.NewLine}WHERE \"t\".\"Name\" = @__Name_0");
+            query.ToQueryString().ShouldBe($".param set @__Name_0 'Something'{Environment.NewLine}{Environment.NewLine}SELECT \"t\".\"Id\", \"t\".\"Created\", \"t\".\"Name\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"{Environment.NewLine}WHERE \"t\".\"Name\" = @__Name_0");
+        }
+
+        [Test]
+        public void UseExpressionify_EvaluationModeAlways_ShouldHandleWhereWithExternalServices()
+        {
+            using var dbContext = new TestDbContext(GetOptions(optionsAction: o => o.WithEvaluationMode(ExpressionEvaluationMode.Always)));
+            var query = dbContext.TestEntities.Where(e => e.IsRecent());
+
+            query.ToQueryString().ShouldBe($".param set @__AddDays_0 '2022-03-03 05:06:07'{Environment.NewLine}{Environment.NewLine}SELECT \"t\".\"Id\", \"t\".\"Created\", \"t\".\"Name\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"{Environment.NewLine}WHERE \"t\".\"Created\" > @__AddDays_0");
+        }
+
+        [Test]
+        public void UseExpressionify_EvaluationModeCached_CannotHandleNewParameters()
+        {
+            using var dbContext = new TestDbContext(GetOptions(optionsAction: o => o.WithEvaluationMode(ExpressionEvaluationMode.Cached)));
+            var query = dbContext.TestEntities.Where(e => e.IsSomething());
+
+            var exception = Should.Throw<InvalidOperationException>(() => query.ToQueryString());
+            exception.Message.ShouldBe("Accessing parameters in a cached query context is not allowed. Explicitly call .Expressionify() on the query or use ExpressionEvaluationMode.Always.");
+        }
+
+        [Test]
+        public void UseExpressionify_EvaluationModeCached_CannotHandleParametersFromExternalServices()
+        {
+            using var dbContext = new TestDbContext(GetOptions(optionsAction: o => o.WithEvaluationMode(ExpressionEvaluationMode.Cached)));
+            var query = dbContext.TestEntities.Where(e => e.IsSomething());
+
+            var exception = Should.Throw<InvalidOperationException>(() => query.ToQueryString());
+            exception.Message.ShouldBe("Accessing parameters in a cached query context is not allowed. Explicitly call .Expressionify() on the query or use ExpressionEvaluationMode.Always.");
         }
 
         [Test]
         public void UseExpressionify_ShouldProduceSameOutputAsExpressionify()
         {
-            using var dbContext = new TestDbContext(GetOptions(useExpressionify: true));
+            using var dbContext = new TestDbContext(GetOptions());
             var queryA = dbContext.TestEntities.Where(e => e.IsSomething());
             var queryB = dbContext.TestEntities.Expressionify().Where(e => e.IsSomething());
 
             queryA.ToQueryString().ShouldBe(queryB.ToQueryString());
         }
 
-        private DbContextOptions GetOptions(bool useExpressionify)
+        [Test]
+        public void UseExpressionify_EvaluationModeAlways_ShouldHandleEvaluatableExpressions()
+        {
+            using var dbContext = new TestDbContext(GetOptions(o => o.WithEvaluationMode(ExpressionEvaluationMode.Always)));
+            var query = dbContext.TestEntities.Select(e => e.ToTestView(null));
+
+            query.ToQueryString().ShouldBe($"SELECT \"t\".\"Name\", NULL AS \"Street\"{Environment.NewLine}FROM \"TestEntities\" AS \"t\"");
+        }
+
+        [Test]
+        public void UseExpressionify_EvaluationModeCached_CannotHandleEvaluatableExpressions()
+        {
+            using var dbContext = new TestDbContext(GetOptions(o => o.WithEvaluationMode(ExpressionEvaluationMode.Cached)));
+            var query = dbContext.TestEntities.Select(e => e.ToTestView(null));
+
+            var exception = Should.Throw<InvalidOperationException>(() => query.ToQueryString());
+            exception.Message.ShouldBe("Accessing parameters in a cached query context is not allowed. Explicitly call .Expressionify() on the query or use ExpressionEvaluationMode.Always.");
+        }
+
+        [TestCase(ExpressionEvaluationMode.Always)]
+        [TestCase(ExpressionEvaluationMode.Cached)]
+        public void UseExpressionify_WithEvaluationMode_SetsEvaluationMode(ExpressionEvaluationMode mode)
+        {
+            var options = GetOptions(o => o.WithEvaluationMode(mode));
+            var extension = options.FindExtension<ExpressionifyDbContextOptionsExtension>()!;
+            
+            var debugInfo = new Dictionary<string, string>();
+            extension.Info.PopulateDebugInfo(debugInfo);
+            
+            debugInfo["Expressionify:EvaluationMode"].ShouldBe(mode.ToString());
+        }
+
+        [Test]
+        public void UseExpressionify_EvaluationMode_DefaultsToAlways()
+        {
+            var options = GetOptions();
+            var extension = options.FindExtension<ExpressionifyDbContextOptionsExtension>()!;
+            
+            var debugInfo = new Dictionary<string, string>();
+            extension.Info.PopulateDebugInfo(debugInfo);
+            
+            debugInfo["Expressionify:EvaluationMode"].ShouldBe(ExpressionEvaluationMode.Always.ToString());
+        }
+
+        private DbContextOptions GetOptions(Action<ExpressionifyDbContextOptionsBuilder>? optionsAction = null, bool useExpressionify = true)
         {
             var builder = new DbContextOptionsBuilder<TestDbContext>().UseSqlite("DataSource=:memory:");
 
             if (useExpressionify)
-                builder.UseExpressionify();
+                builder.UseExpressionify(optionsAction);
 
             return builder.Options;
         }


### PR DESCRIPTION
This is a followup to https://github.com/ClaveConsulting/Expressionify/pull/14:  
I tried to get caching working just out of the box, but long story short, it ended up being fishy and had quite some potential unwanted side effects. The basic issue is simply that query parameters aren't just "introduced to a dictionary", but can change the resulting query expression and thus they mustn't be used to generate an expression that should be cached.

So I ended up taking a simpler approach for now. I basically took the same direction as [EFCore.Projectables](https://github.com/koenbeuk/EntityFrameworkCore.Projectables) and introduced a configuration option for enabling the compiled query cache.

Known limitations for only executing Expressionify when caching a query are documented in the readme. If a to-be-cached query wants to access/add a query parameter, an exception gets thrown (bc. that results to translation exceptions in the best case, to invalid SQLs in a worse case, and to valid, but wrong SQLs in the worst case).