### PR TITLE
fix: Mark Generator as development dependency

### DIFF
--- a/src/Clave.Expressionify.Generator/Clave.Expressionify.Generator.csproj
+++ b/src/Clave.Expressionify.Generator/Clave.Expressionify.Generator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
@@ -13,6 +13,8 @@
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <!-- Do not include the generator as a lib dependency -->
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <!-- Mark as development dependency and include PrivateAssets/IncludeAssets when installing package -->
+        <DevelopmentDependency>true</DevelopmentDependency>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
As noted in the readme, the package `Clave.Expressionify.Generator` should be installed with the `IncludeAssets/PrivateAssets` tags. This does not happen automatically when installing the package, as it is not marked as dev dependency:

![image](https://user-images.githubusercontent.com/20248188/167443036-0a487c0d-fbd6-459f-ad80-f36fb2700c35.png)

This PR fixes that.

Testing:
- Build the nupkg locally
- Add the output dir to the local package sources
- Install the generator package in a new project
- Tags should be present now