### PR TITLE
Fix branch name PR code injection vulnerability

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,9 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(npx -q git-conventional-commits version)-${{ github.event.pull_request.head.ref }}.${{ github.run_number }}" >> $GITHUB_OUTPUT
+        env:
+          PR_REF: ${{ github.event.pull_request.head.ref }}
+        run: echo "version=$(npx -q git-conventional-commits version)-${PR_REF}.${{ github.run_number }}" >> $GITHUB_OUTPUT
 
       # Generate changelog
       - name: Get the changelog


### PR DESCRIPTION
I found this repository while running some scans for my security research.

There is a vulnerability here where someone can use a specially crafted branch name to execute arbitrary code within the context of the `master` branch GitHub Actions and steal the built-in `GITHUB_TOKEN` to modify code, steal secrets, etc. The fix here is to set the ref to a variable before using it within a `run` step.

**IMPORTANT**: This change must be applied to ALL branches that contain the same workflow (because the `pull_request_target` trigger, in this case, does not specify a branch).