### PR TITLE
Fix expression rewriter node replacing

### DIFF
--- a/src/Clave.Expressionify.Generator/Internals/ExpressionRewriter.cs
+++ b/src/Clave.Expressionify.Generator/Internals/ExpressionRewriter.cs
@@ -3,7 +3,7 @@ namespace Clave.Expressionify.Generator.Internals;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
+using System.Linq;
 
 internal sealed class ExpressionRewriter : CSharpSyntaxRewriter
 {
@@ -28,7 +28,10 @@ internal sealed class ExpressionRewriter : CSharpSyntaxRewriter
 
         return _root
             .ReplaceNode(node, res)
-            .FindNode(new TextSpan(node.FullSpan.Start, res.FullSpan.Length));
+            .DescendantNodes()
+            .Where(x => x.FullSpan.Start == node.FullSpan.Start)
+            .Where(x => x.FullSpan.Length == res.FullSpan.Length)
+            .First(x => x.GetType() == res.GetType());
     }
 
     public override SyntaxNode? VisitConditionalAccessExpression(ConditionalAccessExpressionSyntax node)

--- a/tests/Clave.Expressionify.Generator.Tests/CodeGeneratorTests.cs
+++ b/tests/Clave.Expressionify.Generator.Tests/CodeGeneratorTests.cs
@@ -193,10 +193,10 @@ namespace ConsoleApplication1
     public partial class Extensions
     {
         [Expressionify]
-        public static int? GetYear(System.DateTime? x) => x?.Year;
+        public static int? GetYear(DateTime? x) => x?.Year;
 
         [Expressionify]
-        public static string? GetYearString(System.DateTime? x) => (x?.AddDays(1).Year)?.ToString();
+        public static string? GetYearString(DateTime? x) => (x?.AddDays(1).Year)?.ToString();
 
         [Expressionify]
         public static byte? First(byte[]? x) => x?[0];
@@ -206,6 +206,9 @@ namespace ConsoleApplication1
 
         [Expressionify]
         public static int? FirstYear(DateTime?[]? x) => x?[0]?.Year;
+
+        [Expressionify]
+        public static int? GetYearOfNextDay(DateTime? x) => GetYear(x?.AddDays(1));
     }
 }",
 @"#nullable enable
@@ -216,11 +219,12 @@ namespace ConsoleApplication1
 
     public partial class Extensions
     {
-        private static System.Linq.Expressions.Expression<System.Func<System.DateTime?, int?>> GetYear_Expressionify_0() => (System.DateTime? x) => x!.Value.Year;
-        private static System.Linq.Expressions.Expression<System.Func<System.DateTime?, string?>> GetYearString_Expressionify_0() => (System.DateTime? x) => (x!.Value.AddDays(1).Year)!.ToString();
+        private static System.Linq.Expressions.Expression<System.Func<DateTime?, int?>> GetYear_Expressionify_0() => (DateTime? x) => x!.Value.Year;
+        private static System.Linq.Expressions.Expression<System.Func<DateTime?, string?>> GetYearString_Expressionify_0() => (DateTime? x) => (x!.Value.AddDays(1).Year)!.ToString();
         private static System.Linq.Expressions.Expression<System.Func<byte[]?, byte?>> First_Expressionify_0() => (byte[]? x) => x![0];
         private static System.Linq.Expressions.Expression<System.Func<byte[]?, string?>> FirstString_Expressionify_0() => (byte[]? x) => x![0].ToString();
         private static System.Linq.Expressions.Expression<System.Func<DateTime? []?, int?>> FirstYear_Expressionify_0() => (DateTime? []? x) => x![0]!.Value.Year;
+        private static System.Linq.Expressions.Expression<System.Func<DateTime?, int?>> GetYearOfNextDay_Expressionify_0() => (DateTime? x) => GetYear(x!.Value.AddDays(1));
     }
 }", TestName = "Null propagation")]
         public async Task TestGenerator(string source, string generated)


### PR DESCRIPTION
If you write something like

```cs
[Expressionify]
public static int? GetYearOfNextDay(DateTime? x) => GetYear(x?.AddDays(1));
```

the generator yields the error `error EXPR001: Unable to cast object of type 'Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax' to type 'Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax csproj'`

This because several `SyntaxNode`s can occupy the same span. In this case  the span of `x!.Value.AddDays(1)` is occupied by an `ArgumentSyntax` and also by the `ExpressionSyntax` contained in the `ArgumentSyntax`.

This fix replaces the `FindNode` in the `ExpressionRewriter`, by finding a node in the correct span, but also of the correct type.